### PR TITLE
Fix PostgreSQL syntax error in create_default_admin function

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -57,7 +57,7 @@ db = get_db()
 # Create default admin account if no users exist
 def create_default_admin():
     """Create default admin account (admin/admin) if no users exist"""
-    cursor = db.conn.cursor()
+    cursor = db._get_cursor()
     cursor.execute("SELECT COUNT(*) FROM users")
     user_count = cursor.fetchone()[0]
 


### PR DESCRIPTION
- Changed cursor = db.conn.cursor() to cursor = db._get_cursor()
- Direct conn.cursor() bypasses the converting_execute wrapper
- This caused '?' placeholders to not be converted to '%s' for PostgreSQL
- Now uses wrapped cursor that auto-converts SQLite syntax to PostgreSQL

Fixes deployment error:
  psycopg2.errors.SyntaxError: syntax error at or near "," VALUES (?, ?, ?, ?, ?, ?)