### PR TITLE
Fix timeout issue by adding missing create_listing route

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -174,6 +174,11 @@ def index():
     else:
         return render_template('index.html')
 
+@app.route('/create')
+def create_listing():
+    """Create new listing page"""
+    return render_template('create.html')
+
 @app.route('/drafts')
 @login_required
 def drafts():


### PR DESCRIPTION
The app was timing out on health checks because the index.html template was calling url_for('create_listing') but this route didn't exist. This caused Flask to throw an exception when rendering the template, crashing the worker and preventing Render from getting a response to its health check.

Added /create route that renders create.html template to fix the issue.