### PR TITLE
Fix template paths for storage pages

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -187,13 +187,13 @@ def notifications():
 @login_required
 def storage():
     """Storage overview"""
-    return render_template('storage/index.html')
+    return render_template('storage.html')
 
 @app.route('/storage/clothing')
 @login_required
 def storage_clothing():
     """Clothing storage"""
-    return render_template('storage/clothing.html')
+    return render_template('storage_clothing.html')
 
 @app.route('/storage/cards')
 @login_required
@@ -205,7 +205,7 @@ def storage_cards():
 @login_required
 def storage_map():
     """Storage map"""
-    return render_template('storage/map.html')
+    return render_template('storage_map.html')
 
 @app.route('/settings')
 @login_required


### PR DESCRIPTION
Fixed 500 errors on storage pages caused by incorrect template paths:

- /storage now renders 'storage.html' instead of 'storage/index.html'
- /storage/clothing now renders 'storage_clothing.html' instead of 'storage/clothing.html'
- /storage/map now renders 'storage_map.html' instead of 'storage/map.html'

The templates are in the root templates directory, not in a storage subdirectory.