### PR TITLE
Fix photo uploads: Fix JavaScript syntax error in template

### DIFF
--- a/templates/create.html
+++ b/templates/create.html
@@ -224,7 +224,7 @@
 {% block extra_js %}
 <script>
 let uploadedPhotos = [];
-let editingDraftId = {{ draft_id if draft_id else 'null' }};
+let editingDraftId = {% if draft_id %}{{ draft_id }}{% else %}null{% endif %};
 let editingListingUuid = null;
 
 // Generic photo handling function for both camera and file upload


### PR DESCRIPTION
Fixed SyntaxError caused by bad Jinja template rendering:

OLD (broken):
let editingDraftId = {{ draft_id if draft_id else 'null' }};

When draft_id is undefined, this renders as:
let editingDraftId = ;  // ← SYNTAX ERROR

NEW (fixed):
let editingDraftId = {% if draft_id %}{{ draft_id }}{% else %}null{% endif %};

Properly renders as:
let editingDraftId = null;

This was causing 'string didn't match the value' SyntaxError and preventing ALL JavaScript on the page from running, including photo upload code.