### PR TITLE
Fix Supabase connection issues with transaction pooler

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     plan: free
     branch: claude/investigate-landing-page-01Ncg5Bwtm44WFZjQ62UTdp8
     buildCommand: pip install --upgrade pip && pip install gunicorn && pip install -r requirements.txt
-    startCommand: gunicorn web_app:app --bind 0.0.0.0:$PORT --workers 2 --timeout 120 --worker-class gevent
+    startCommand: gunicorn web_app:app --bind 0.0.0.0:$PORT --workers 1 --timeout 120 --threads 4
     maxUploadSizeMB: 50
     disk:
       name: uploads


### PR DESCRIPTION
- Change gunicorn to 1 worker with 4 threads (avoids simultaneous auth)
- Add sslmode=require for Supabase pooler connections
- Set statement_timeout for transaction pooling compatibility
- Remove gevent worker class (not installed, causing fallback to sync)

The "duplicate SASL authentication request" error was caused by 2 workers trying to authenticate simultaneously during startup. Using 1 worker with threads solves this while maintaining concurrency.