### PR TITLE
Fix Photo initialization - url is required parameter, not local_path

### DIFF
--- a/routes_main.py
+++ b/routes_main.py
@@ -579,6 +579,9 @@ def get_api_credentials(platform):
 
         return jsonify({"success": True, "configured": False})
     except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
 # -------------------------------------------------------------------------
 # CARD ANALYSIS (TCG + Sports) - QUICK ANALYSIS
 # -------------------------------------------------------------------------


### PR DESCRIPTION
Fixed missing except block body that caused IndentationError. Added proper error handling to get_api_credentials endpoint.