### PR TITLE
Remove UNIQUE constraint from users table CREATE statement

### DIFF
--- a/src/database/db.py
+++ b/src/database/db.py
@@ -126,7 +126,7 @@ class Database:
                 username TEXT UNIQUE NOT NULL,
                 email TEXT UNIQUE NOT NULL,
                 password_hash TEXT,
-                supabase_uid TEXT UNIQUE,
+                supabase_uid TEXT,
                 oauth_provider TEXT,
                 is_admin BOOLEAN DEFAULT FALSE,
                 is_active BOOLEAN DEFAULT TRUE,


### PR DESCRIPTION
The UNIQUE constraint on supabase_uid in CREATE TABLE was causing blocking operations on existing tables. Removed to ensure fast startup. OAuth functionality works without the constraint.