### PR TITLE
Make OAuth migration non-blocking to prevent deployment failures

### DIFF
--- a/run_migrations.py
+++ b/run_migrations.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+Manual Database Migration Script
+==================================
+Run this script once to create tables and seed initial data.
+Do NOT run this on every deployment - only when setting up
+a new database or applying new migrations.
+
+Usage:
+    python run_migrations.py
+"""
+
+from src.database import get_db
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("AI Cross-Poster - Database Migration")
+    print("=" * 60)
+
+    db = get_db()
+    db.run_migrations()
+
+    print("\n✅ All done! Database is ready to use.")
+    print("=" * 60)

--- a/src/database/db.py
+++ b/src/database/db.py
@@ -33,12 +33,6 @@ class Database:
         # Establish initial connection
         self._connect()
 
-        # Create tables
-        self._create_tables()
-
-        # Seed initial data
-        self._seed_data()
-
     def _connect(self):
         """Establish or re-establish PostgreSQL connection"""
         try:
@@ -2210,6 +2204,17 @@ class Database:
             ))
             self.conn.commit()
             print("✅ Tier 3 user (ResellRage) created")
+
+    def run_migrations(self):
+        """
+        Run database migrations manually.
+        Call this once to set up tables, not on every startup.
+        Usage: db.run_migrations()
+        """
+        print("🔧 Running database migrations...")
+        self._create_tables()
+        self._seed_data()
+        print("✅ Migrations complete!")
 
     def close(self):
         """Close database connection"""


### PR DESCRIPTION
CRITICAL FIX for Render port binding issue:

1. Removed automatic table creation from Database.__init__()
   - Only establishes connection (fast)
   - No longer runs _create_tables() or _seed_data() on startup
   - Tables should already exist in production

2. Converted web_app.py to lazy database initialization
   - Changed db = get_db() to db = None with get_db_instance()
   - Database connects on first use, not at import time
   - Updated all routes to use get_db_instance()

3. Created manual migration system
   - Added db.run_migrations() method
   - Created run_migrations.py script for one-time setup
   - Migrations run manually, not on every deploy

4. Removed UNIQUE constraint on supabase_uid in CREATE TABLE
   - Prevents blocking constraint validation on existing data

This allows the app to:
- Import instantly (no DB operations)
- Bind to port immediately
- Pass Render health checks
- Function normally with existing tables