### PR TITLE
Fix analyze buttons, storage page, and API endpoints

### DIFF
--- a/templates/create.html
+++ b/templates/create.html
@@ -701,14 +701,8 @@ document.getElementById('analyzeBtn').addEventListener('click', async function()
                     enhancedBtn.classList.remove('btn-outline-warning');
                     enhancedBtn.classList.add('btn-warning');
                     enhancedBtn.title = 'Click for detailed collectible analysis';
-                } else {
-                    // Enable enhanced analyzer for all items (works best with collectibles)
-                    const enhancedBtn = document.getElementById('enhancedAnalyzerBtn');
-                    enhancedBtn.disabled = false;
-                    enhancedBtn.classList.remove('btn-outline-warning');
-                    enhancedBtn.classList.add('btn-warning');
-                    enhancedBtn.title = 'Run enhanced analysis (works best with collectibles and cards)';
                 }
+                // Don't enable enhanced analyzer if no collectible detected
 
                 // Show market analysis (sell-through rate)
                 if (analysis.market_analysis) {

--- a/web_app.py
+++ b/web_app.py
@@ -223,19 +223,32 @@ def storage():
 @login_required
 def storage_clothing():
     """Clothing storage"""
-    return render_template('storage_clothing.html')
+    bins = get_db_instance().get_storage_bins(current_user.id, bin_type='clothing')
+    # Add section counts to each bin
+    for bin in bins:
+        sections = get_db_instance().get_storage_sections(bin['id'])
+        bin['section_count'] = len(sections)
+        bin['sections'] = sections
+    return render_template('storage_clothing.html', bins=bins)
 
 @app.route('/storage/cards')
 @login_required
 def storage_cards():
     """Card storage"""
-    return redirect(url_for('cards.cards_collection'))
+    bins = get_db_instance().get_storage_bins(current_user.id, bin_type='cards')
+    # Add section counts to each bin
+    for bin in bins:
+        sections = get_db_instance().get_storage_sections(bin['id'])
+        bin['section_count'] = len(sections)
+        bin['sections'] = sections
+    return render_template('storage_cards.html', bins=bins)
 
 @app.route('/storage/map')
 @login_required
 def storage_map():
     """Storage map"""
-    return render_template('storage_map.html')
+    storage_map_data = get_db_instance().get_storage_map(current_user.id)
+    return render_template('storage_map.html', storage_map=storage_map_data)
 
 @app.route('/settings')
 @login_required


### PR DESCRIPTION
Changes:
- Fix Enhanced Analyzer button to only enable for collectibles/cards Previously enabled for all items after analysis Now only enables when a collectible or card is detected

- Add all missing storage API endpoints (/api/storage/*)
  - GET /api/storage/bins - Get storage bins
  - POST /api/storage/create-bin - Create new bin
  - POST /api/storage/create-section - Create section in bin
  - GET /api/storage/items - Get items (optionally by bin)
  - POST /api/storage/add-item - Add item with auto-generated storage ID
  - GET /api/storage/find - Find item by storage ID

- Fix storage page routes to pass correct template data
  - /storage/clothing now passes bins data
  - /storage/cards now renders template instead of redirecting
  - /storage/map now passes storage_map data

All storage functionality should now work properly.