### PR TITLE
Fix flask-testing version requirement for deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,4 @@ stripe>=7.0.0  # Stripe integration for subscriptions
 # Development dependencies
 pytest>=7.4.0
 pytest-cov>=4.1.0
-flask-testing>=1.0.0
+flask-testing>=0.8.0


### PR DESCRIPTION
Changed flask-testing from >=1.0.0 to >=0.8.0 (latest available version is 0.8.1)