### PR TITLE
Fix AI analyzers draft saving and UUID type errors

### DIFF
--- a/src/database/db.py
+++ b/src/database/db.py
@@ -982,16 +982,16 @@ class Database:
         """Create a new listing - user_id can be UUID or integer"""
         cursor = self._get_cursor()
 
-        # Convert user_id to string to handle both UUID and int
+        # user_id is INTEGER in listings table
         cursor.execute("""
             INSERT INTO listings (
                 listing_uuid, user_id, collectible_id, title, description, price,
                 cost, condition, category, item_type, attributes, photos, quantity,
                 storage_location, sku, upc, status
-            ) VALUES (%s, %s::text::uuid, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
         """, (
-            listing_uuid, str(user_id), collectible_id, title, description, price,
+            listing_uuid, int(user_id), collectible_id, title, description, price,
             cost, condition, category, item_type,
             json.dumps(attributes) if attributes else None,
             json.dumps(photos),
@@ -1602,12 +1602,12 @@ class Database:
         cursor.execute("""
             INSERT INTO marketplace_credentials
             (user_id, platform, username, password, updated_at)
-            VALUES (%s::text::uuid, %s, %s, %s, CURRENT_TIMESTAMP)
+            VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP)
             ON CONFLICT (user_id, platform) DO UPDATE SET
                 username = EXCLUDED.username,
                 password = EXCLUDED.password,
                 updated_at = CURRENT_TIMESTAMP
-        """, (str(user_id), platform, username, password))
+        """, (int(user_id), platform, username, password))
 
         self.conn.commit()
 

--- a/templates/create.html
+++ b/templates/create.html
@@ -1271,6 +1271,10 @@ async function saveListing(status = 'draft') {
     // include uploaded server photo paths
     formData.photos = uploadedPhotos;
     formData.status = status;
+    // Include AI analysis data if available
+    if (enhancedAnalysisData) {
+        formData.enhanced_analysis = enhancedAnalysisData;
+    }
     showLoading();
 
     try {


### PR DESCRIPTION
- Frontend: Include enhanced_analysis data when saving drafts (create.html)
- Backend: Create collectible entries from AI analysis data (routes_main.py)
- Backend: Link listings to collectibles via collectible_id
- Backend: Save deep analysis to collectibles table for RAG
- Database: Fix user_id type casting from UUID to INTEGER (db.py)
- Database: Remove incorrect ::text::uuid casts in listings and marketplace_credentials

This allows AI analysis data to persist when saving drafts, enabling:
- Future RAG-enhanced analyses based on similar collectibles
- Proper collectible tracking and linking
- Successful draft saves without UUID type errors