### PR TITLE
Fix critical bug: OAuth login never commits to database

### DIFF
--- a/src/database/db.py
+++ b/src/database/db.py
@@ -1985,6 +1985,7 @@ class Database:
                 RETURNING id
             """, (str(user_uuid), username, email, supabase_uid, oauth_provider))
             result = cursor.fetchone()
+            self.conn.commit()  # Commit the transaction
             return str(result['id'])
         finally:
             if cursor:
@@ -2009,6 +2010,7 @@ class Database:
                     email_verified = TRUE
                 WHERE id::text = %s
             """, (supabase_uid, oauth_provider, user_id_str))
+            self.conn.commit()  # Commit the transaction
         finally:
             if cursor:
                 try:
@@ -2104,6 +2106,7 @@ class Database:
                 json.dumps(details) if details else None,
                 ip_address, user_agent
             ))
+            self.conn.commit()  # Commit the transaction
         except Exception as e:
             # Silently skip activity logging if it fails
             print(f"⚠️  Activity logging skipped: {e}")


### PR DESCRIPTION
Problem:
- Users could not login with Google OAuth or regular credentials
- create_oauth_user() was missing self.conn.commit()
- link_supabase_account() was missing self.conn.commit()
- log_activity() was missing self.conn.commit()
- All INSERT/UPDATE operations were being rolled back
- Users were never actually created or linked in the database

Root Cause:
- These methods declared conn = None but never assigned it
- They called _return_connection(conn, commit=True) which does nothing when conn is None
- Unlike create_user() which properly calls self.conn.commit(), these methods forgot to commit

Changes:
- Added self.conn.commit() to create_oauth_user() before return
- Added self.conn.commit() to link_supabase_account() after UPDATE
- Added self.conn.commit() to log_activity() after INSERT

This fix ensures all login methods (OAuth and regular) properly save to database.