### PR TITLE
Fix worker timeout - close transactions after read operations

### DIFF
--- a/src/database/db.py
+++ b/src/database/db.py
@@ -1828,6 +1828,8 @@ class Database:
                 cursor = self._get_cursor()
                 cursor.execute("SELECT * FROM users WHERE username = %s", (username,))
                 row = cursor.fetchone()
+                # Commit to close transaction (no-op for SELECT but prevents hanging)
+                self.conn.commit()
                 return dict(row) if row else None
             except (psycopg2.OperationalError, psycopg2.InterfaceError) as e:
                 if attempt < max_retries - 1:
@@ -1858,6 +1860,8 @@ class Database:
                 cursor = self._get_cursor()
                 cursor.execute("SELECT * FROM users WHERE email = %s", (email,))
                 row = cursor.fetchone()
+                # Commit to close transaction (no-op for SELECT but prevents hanging)
+                self.conn.commit()
                 return dict(row) if row else None
             except (psycopg2.OperationalError, psycopg2.InterfaceError) as e:
                 if attempt < max_retries - 1:
@@ -1888,11 +1892,14 @@ class Database:
                 user_id_str = str(user_id) if user_id else None
                 if not user_id_str:
                     return None
-                
+
                 cursor = self._get_cursor()
                 cursor.execute("SELECT * FROM users WHERE id::text = %s", (user_id_str,))
                 row = cursor.fetchone()
-                
+
+                # Commit to close transaction (no-op for SELECT but prevents hanging)
+                self.conn.commit()
+
                 if row:
                     result = dict(row)
                     # Ensure id is returned as string UUID
@@ -1961,6 +1968,8 @@ class Database:
             cursor = self._get_cursor()
             cursor.execute("SELECT * FROM users WHERE supabase_uid = %s", (supabase_uid,))
             row = cursor.fetchone()
+            # Commit to close transaction (no-op for SELECT but prevents hanging)
+            self.conn.commit()
             return dict(row) if row else None
         finally:
             if cursor:


### PR DESCRIPTION
Problem:
- Workers were timing out after 5 minutes (300s) and being killed
- Login requests would hang indefinitely
- SELECT queries (get_user_by_username, get_user_by_email, etc.) were leaving transactions open
- PostgreSQL connections don't autocommit, so every SELECT starts a transaction
- Open transactions on the persistent connection caused subsequent operations to hang

Root Cause:
- Database uses a singleton instance with persistent self.conn
- Read methods like get_user_by_username() execute SELECT but never commit/rollback
- Connection is left with an open transaction
- Next operation on same connection hangs waiting for transaction to close

Changes:
- Added self.conn.commit() after SELECT in get_user_by_username()
- Added self.conn.commit() after SELECT in get_user_by_email()
- Added self.conn.commit() after SELECT in get_user_by_id()
- Added self.conn.commit() after SELECT in get_user_by_supabase_uid()

The commit is a no-op for read-only SELECT queries but ensures transaction is closed cleanly. This prevents connection from getting stuck in transaction state and eliminates worker timeouts.