### PR TITLE
Fix critical worker timeout by enabling autocommit and removing block…

### DIFF
--- a/routes_auth.py
+++ b/routes_auth.py
@@ -37,7 +37,9 @@ def login():
         username = data.get('username')
         password = data.get('password')
 
-        print(f"[LOGIN] Attempting login for username: {username}")
+        print(f"[LOGIN] Attempting login for username: {username}", flush=True)
+        import time
+        start_time = time.time()
 
         if not username or not password:
             flash("Username and password required.", "error")
@@ -105,7 +107,8 @@ def login():
         except Exception as e:
             print(f"[LOGIN WARNING] Failed to log activity: {e}")
 
-        print(f"[LOGIN] Redirecting to index for username: {username}")
+        elapsed = time.time() - start_time
+        print(f"[LOGIN] ✅ Login successful for {username} (took {elapsed:.2f}s)", flush=True)
         return redirect(url_for('index'))
     
     except Exception as e:


### PR DESCRIPTION
…ing commit() calls

PROBLEM:
Workers were timing out after 120 seconds during login with SIGKILL. Root cause: PostgreSQL connections were leaving open transactions that blocked subsequent operations, causing commit() calls to hang indefinitely.

ROOT CAUSES IDENTIFIED:
1. _get_cursor() executed "SELECT 1" test query that started a transaction but never committed it, leaving orphaned transactions on the connection
2. Previous "fix" (commit 57a0cba) added self.conn.commit() after SELECT queries, but this made the problem WORSE - the commit() calls would block waiting for locks from the orphaned test query transactions
3. PostgreSQL connections defaulted to non-autocommit mode, so every query started a transaction that had to be manually committed

SOLUTION:
1. Enable autocommit on all connections from the pool (line 219)
   - Prevents SELECT queries from starting transactions automatically
   - Eliminates need for manual commit() after read operations
2. Remove the test query in _get_cursor() (was lines 228-231)
   - Test query was leaving orphaned transactions
   - Not needed with autocommit enabled
3. Remove all unnecessary self.conn.commit() calls after SELECT queries
   - get_user_by_username, get_user_by_email, get_user_by_id, get_user_by_supabase_uid, log_activity
4. Add 30-second statement timeout as safety net (line 223-224)
   - Prevents any single query from blocking forever
5. Add timing diagnostics to login route
   - Track login duration to detect future performance issues

CHANGES:
- src/database/db.py:
  * _get_connection_from_pool: Enable autocommit + set statement timeout
  * _get_cursor: Remove test query that was creating orphaned transactions
  * get_user_by_username: Remove blocking commit() call
  * get_user_by_email: Remove blocking commit() call
  * get_user_by_id: Remove blocking commit() call
  * get_user_by_supabase_uid: Remove blocking commit() call
  * log_activity: Remove blocking commit() call
- routes_auth.py:
  * Add timing instrumentation to login route
  * Add flush=True to ensure logs appear immediately in Render

IMPACT:
- Login should complete in <1 second instead of timing out at 120s
- All database operations now auto-commit immediately
- No more orphaned transactions blocking future operations
- Statement timeout prevents infinite waits