### PR TITLE
CRITICAL FIX: Implement Flask-Session filesystem backend for persiste…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ data/*.db-journal
 
 # Draft photos storage
 data/draft_photos/
+
+# Flask session storage (server-side sessions)
+flask_session/
+data/flask_session/

--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,9 @@ services:
     region: oregon
     plan: free
     branch: main
+    # CRITICAL: Disable autoscaling - filesystem sessions require single instance
+    autoDeploy: true
+    numInstances: 1
     buildCommand: pip install --upgrade pip && pip install gunicorn && pip install -r requirements.txt
     startCommand: gunicorn web_app:app --bind 0.0.0.0:$PORT --workers 1 --worker-class sync --timeout 120
     maxUploadSizeMB: 50

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,8 @@ customtkinter>=5.2.0
 # Web app
 flask>=3.0.0
 flask-login>=0.6.3
+flask-session>=0.6.0  # Server-side session storage for multi-worker support
+cachelib>=0.10.0  # Required by flask-session
 werkzeug>=3.0.0
 gunicorn>=21.2.0  # Production WSGI server for Render deployment
 gevent>=23.9.1  # Async worker for better upload handling
@@ -30,6 +32,7 @@ psycopg2-binary>=2.9.9  # PostgreSQL adapter
 
 # Authentication (Supabase OAuth)
 supabase>=2.3.0  # Supabase Python client
+httpx>=0.25.0  # HTTP client for OAuth token exchange
 pyjwt>=2.8.0  # JWT token handling
 passlib[bcrypt]>=1.7.4  # Password hashing
 python-jose[cryptography]>=3.3.0  # JWT creation and validation

--- a/web_app.py
+++ b/web_app.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from functools import wraps
 from flask import Flask, render_template, redirect, url_for, flash
 from flask_login import LoginManager, UserMixin, login_required, current_user
+from flask_session import Session
 from werkzeug.security import generate_password_hash
 from dotenv import load_dotenv
 
@@ -66,6 +67,31 @@ print(f"🔧 Session configuration:", flush=True)
 print(f"   - Cookie SameSite: {app.config['SESSION_COOKIE_SAMESITE']}", flush=True)
 print(f"   - Cookie Secure: {app.config['SESSION_COOKIE_SECURE']}", flush=True)
 print(f"   - Cookie HTTPOnly: {app.config['SESSION_COOKIE_HTTPONLY']}", flush=True)
+
+# ============================================================================
+# FLASK-SESSION CONFIGURATION (Server-side session storage)
+# ============================================================================
+# CRITICAL: Use filesystem-based sessions to persist across workers/restarts
+# This fixes the "flow_state_not_found" error from Supabase OAuth
+
+# Create session directory in data folder (survives restarts if on persistent disk)
+session_dir = Path('./data/flask_session')
+session_dir.mkdir(parents=True, exist_ok=True)
+
+app.config['SESSION_TYPE'] = 'filesystem'  # Store sessions on disk
+app.config['SESSION_FILE_DIR'] = str(session_dir)
+app.config['SESSION_PERMANENT'] = False  # Session expires when browser closes
+app.config['SESSION_USE_SIGNER'] = True  # Sign session cookies for security
+app.config['SESSION_FILE_THRESHOLD'] = 500  # Max number of session files
+
+# Initialize Flask-Session
+Session(app)
+
+print(f"✅ Flask-Session initialized:", flush=True)
+print(f"   - Type: filesystem", flush=True)
+print(f"   - Directory: {session_dir.absolute()}", flush=True)
+print(f"   - Permanent: False", flush=True)
+print(f"   - Use Signer: True", flush=True)
 
 # Ensure upload folder exists
 Path(app.config['UPLOAD_FOLDER']).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
…nt sessions

PROBLEM: "flow_state_not_found" error from Supabase ========================================================= Users experiencing OAuth callback failures with Supabase error:
  HTTP 404: flow_state_not_found

This error means Supabase's internal flow state was lost, which happens when:
1. Our Flask session containing code_verifier is lost between requests
2. Session cookies not persisting across OAuth redirect
3. Multi-worker environment without shared session storage

ROOT CAUSE:
===========
Flask's default client-side signed cookie sessions are NOT persisting reliably:
- On Render with restarts/redeploys, sessions get lost
- With 2 workers, session state is not shared
- OAuth redirects from Supabase may not include session cookies

SOLUTION:
=========
Implement Flask-Session with FILESYSTEM backend for server-side session storage.

Changes:
--------
1. requirements.txt: ✅ Added flask-session>=0.6.0 for server-side sessions ✅ Added cachelib>=0.10.0 (required by flask-session) ✅ Added httpx>=0.25.0 (used in OAuth token exchange)

2. web_app.py (lines 71-94): ✅ Configured SESSION_TYPE='filesystem' ✅ Created persistent session directory: ./data/flask_session ✅ Enabled SESSION_USE_SIGNER for security ✅ Set SESSION_PERMANENT=False (expires on browser close) ✅ Added comprehensive startup logging

3. render.yaml: ✅ Added numInstances: 1 to prevent autoscaling ✅ Filesystem sessions require single instance OR Redis

4. .gitignore: ✅ Added flask_session/ and data/flask_session/ to ignore

HOW IT WORKS:
=============
BEFORE (Client-side sessions):
- Session data stored in signed cookie
- Cookie sent with each request
- Problem: OAuth redirects may not include cookie
- Problem: Render restarts can invalidate secret key

AFTER (Server-side filesystem sessions):
- Session data stored on disk in ./data/flask_session/
- Only session ID stored in cookie
- Session persists across requests
- code_verifier survives OAuth redirect roundtrip
- All workers on same instance share session storage

TESTING:
========
After deployment, verify in logs:

On Startup:
-----------
✅ Flask-Session initialized:
   - Type: filesystem
   - Directory: /opt/render/project/src/data/flask_session
   - Permanent: False
   - Use Signer: True

On OAuth Login:
---------------
🟢 [LOGIN_GOOGLE] Starting OAuth flow
🔍 [LOGIN_GOOGLE] Session before OAuth: {}
🔍 [LOGIN_GOOGLE] Session after OAuth: {'oauth_code_verifier': '...'} ✅ [LOGIN_GOOGLE] Session marked as modified

On OAuth Callback:
------------------
🔵 [CALLBACK] OAuth callback handler STARTED
✅ [CALLBACK] Session keys present: ['oauth_code_verifier'] ✅ [CALLBACK] Retrieved code verifier from session: ...

ENVIRONMENT CHECKLIST:
======================
Verify these are set in Render dashboard:

☑️ FLASK_SECRET_KEY (generated by Render, permanent) ☑️ FLASK_ENV=production
☑️ SUPABASE_URL=https://your-project.supabase.co
☑️ SUPABASE_ANON_KEY=...
☑️ SUPABASE_REDIRECT_URL=https://resell-genie.onrender.com/auth/callback

IMPORTANT: Ensure callback URL matches EXACTLY in:
- Render environment variables
- Supabase dashboard OAuth settings
- Google Cloud Console OAuth credentials

SCALING NOTES:
==============
Current configuration: 1 worker, 1 instance (filesystem sessions)

For scaling beyond 1 instance, implement Redis sessions:
  app.config['SESSION_TYPE'] = 'redis'
  app.config['SESSION_REDIS'] = Redis(...)

This will allow multiple instances to share session data via Redis.