### PR TITLE
Fix IndentationError in routes_auth.py

### DIFF
--- a/routes_auth.py
+++ b/routes_auth.py
@@ -520,7 +520,7 @@ def auth_callback():
                     user_data = session_data.get("data", {}).get("user", {})
             else:
                 # If it's an object with attributes
-               exchange_code_for_session(code, code_verifier, redirect_url)
+                user_data = getattr(session_data, 'user', {})
                 if not user_data:
                     user_data = getattr(session_data, 'data', {}).get('user', {}) if hasattr(session_data, 'data') else {}
             


### PR DESCRIPTION
Fixed incorrect indentation and logic error on line 523. The line was:
- Indented with wrong number of spaces (causing IndentationError)
- Calling exchange_code_for_session() again (incorrect logic)

Now properly extracts user_data from session_data object.