### PR TITLE
Add robust error handling for photo uploads

### DIFF
--- a/templates/create.html
+++ b/templates/create.html
@@ -495,8 +495,13 @@ async function handlePhotoSelect(e) {
         formData.append('photos', file);
     }
 
-    console.log('[UPLOAD] Showing loading spinner');
-    showLoading();
+    // Show loading spinner (with error handling)
+    try {
+        console.log('[UPLOAD] Showing loading spinner');
+        showLoading();
+    } catch (err) {
+        console.warn('[UPLOAD] showLoading error:', err);
+    }
 
     try {
         console.log('[UPLOAD] Sending fetch request to /api/upload-photos');
@@ -544,10 +549,16 @@ async function handlePhotoSelect(e) {
         }
     } catch (error) {
         console.error('[UPLOAD] Exception caught:', error);
-        showAlert('Upload failed: ' + error, 'danger');
+        console.error('[UPLOAD] Error details:', error.message, error.stack);
+        showAlert('Upload failed: ' + error.message, 'danger');
     } finally {
-        console.log('[UPLOAD] Hiding loading spinner');
-        hideLoading();
+        // Hide loading spinner (with error handling)
+        try {
+            console.log('[UPLOAD] Hiding loading spinner');
+            hideLoading();
+        } catch (err) {
+            console.warn('[UPLOAD] hideLoading error:', err);
+        }
     }
 
     // Reset input so same file can be selected again


### PR DESCRIPTION
- Wrap showLoading/hideLoading in try-catch to prevent blocking
- Add detailed error logging for debugging
- Show error.message instead of error object in alerts
- Helps diagnose upload failures in browser console

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap `showLoading`/`hideLoading` in try/catch and display `error.message` with added logging during photo uploads.
> 
> - **UI (create page)**
>   - In `templates/create.html`:
>     - Wrap `showLoading()`/`hideLoading()` in try/catch around photo upload to prevent spinner errors from blocking flow.
>     - Enhance logging with `error.message` and `error.stack`; show alerts using `error.message` instead of the full error object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 190cea04adb00c6540ac067760bd27247698154c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->