### PR TITLE
Remove redirect_uri from Supabase PKCE token exchange

### DIFF
--- a/src/auth_utils.py
+++ b/src/auth_utils.py
@@ -190,14 +190,14 @@ def exchange_code_for_session(auth_code: str, code_verifier: str = None, redirec
             "apikey": supabase_key,
             "Content-Type": "application/json"
         }
+        # PKCE only requires code and code_verifier, NOT redirect_uri
         payload = {
             "code": auth_code,
-            "code_verifier": code_verifier,
-            "redirect_uri": redirect_uri
+            "code_verifier": code_verifier
         }
 
         print(f"Making direct request to: {url}")
-        print(f"Payload: {payload}")
+        print(f"Payload (PKCE): {payload}")
 
         response = httpx.post(url, headers=headers, json=payload, timeout=30.0)
 


### PR DESCRIPTION
CRITICAL FIX: redirect_uri not needed for PKCE flow!

Problem:
- OAuth 2.0 PKCE spec only requires 'code' and 'code_verifier' for token exchange
- We were also sending 'redirect_uri' which was causing validation errors
- Supabase was rejecting with misleading error: 'both auth code and code verifier should be non-empty'

Solution:
- Removed redirect_uri from the payload entirely
- PKCE proves the flow was initiated by the same client via code_verifier
- No need to also verify redirect_uri

This is the actual fix that should make OAuth work!