### PR TITLE
Fix Supabase PKCE token exchange - move grant_type to request body

### DIFF
--- a/src/auth_utils.py
+++ b/src/auth_utils.py
@@ -189,13 +189,15 @@ def exchange_code_for_session(auth_code: str, code_verifier: str = None) -> Opti
         # Make direct HTTP request to Supabase Auth API
         import httpx
 
-        url = f"{supabase_url}/auth/v1/token?grant_type=pkce"
+        url = f"{supabase_url}/auth/v1/token"
         headers = {
             "apikey": supabase_key,
             "Content-Type": "application/json"
         }
-        # PKCE only requires code and code_verifier, NOT redirect_uri
+        # PKCE token exchange requires grant_type in body, not query params
+        # Supabase expects: grant_type, code (not auth_code), code_verifier
         payload = {
+            "grant_type": "pkce",
             "code": auth_code,
             "code_verifier": code_verifier
         }


### PR DESCRIPTION
PROBLEM IDENTIFIED:
==================
Supabase was rejecting the PKCE token exchange with error: "invalid request: both auth code and code verifier should be non-empty"

Even though both values were clearly non-empty in the payload.

ROOT CAUSE:
===========
The grant_type was being sent as a URL query parameter:
  ❌ /auth/v1/token?grant_type=pkce

But Supabase expects grant_type in the request BODY, per OAuth 2.0 spec.

FIX APPLIED:
============
1. Removed grant_type from URL query parameters
2. Added grant_type to the request body payload
3. Now sending: ✅ URL: /auth/v1/token ✅ Body: {"grant_type": "pkce", "code": "...", "code_verifier": "..."}

This matches the OAuth 2.0 specification and Supabase Auth API expectations.

TESTING:
========
Logs will now show the corrected payload format with grant_type included. Expected result: HTTP 200 from Supabase with user session data.