### PR TITLE
Fix TWO critical OAuth bugs: database column typo + wrong grant_type

### DIFF
--- a/src/auth_utils.py
+++ b/src/auth_utils.py
@@ -194,10 +194,10 @@ def exchange_code_for_session(auth_code: str, code_verifier: str = None) -> Opti
             "apikey": supabase_key,
             "Content-Type": "application/json"
         }
-        # PKCE token exchange requires grant_type in body, not query params
-        # Supabase expects: grant_type, code (not auth_code), code_verifier
+        # PKCE token exchange: grant_type must be "authorization_code" with code_verifier present
+        # Standard OAuth 2.0 PKCE extension uses authorization_code grant type
         payload = {
-            "grant_type": "pkce",
+            "grant_type": "authorization_code",
             "code": auth_code,
             "code_verifier": code_verifier
         }

--- a/src/database/db.py
+++ b/src/database/db.py
@@ -114,7 +114,7 @@ class Database:
 
                 # Add supabase_uid column if it doesn't exist
                 cursor.execute("""
-                    ALTER TABLE users ADD COLUMN IF NOT EXISTS supabase_uuid TEXT;
+                    ALTER TABLE users ADD COLUMN IF NOT EXISTS supabase_uid TEXT;
                 """)
 
                 # Add oauth_provider column if it doesn't exist


### PR DESCRIPTION
PROBLEM 1 - Database Column Typo:
==================================
❌ Migration created column: supabase_uuid (with extra 'u')
✅ Code was querying for:    supabase_uid (correct name)

Result: Database queries failed because column didn't exist!

This caused:
- get_user_by_supabase_uid() to always return None
- create_oauth_user() to fail inserting supabase_uid
- link_supabase_account() to fail updating supabase_uid

FIX: Changed migration from supabase_uuid to supabase_uid

PROBLEM 2 - Wrong Grant Type:
==============================
❌ Was sending: grant_type="pkce"
✅ Should send:  grant_type="authorization_code"

Per OAuth 2.0 RFC 7636 (PKCE), the grant_type must be "authorization_code" with the code_verifier parameter present. "pkce" is NOT a valid grant_type.

Supabase correctly rejected with: "unsupported_grant_type"

FIX: Changed grant_type to "authorization_code"

TESTING:
========
After these fixes:
1. Database column will match what code expects
2. Token exchange will use correct grant_type
3. OAuth flow should complete successfully

Next deploy should show:
✅ Response status: 200
✅ Exchange successful!
✅ OAuth login successful!