### PR TITLE
Try disabling SSL completely to fix database timeouts

### DIFF
--- a/src/database/db.py
+++ b/src/database/db.py
@@ -32,14 +32,14 @@ def _get_connection_pool():
         # Parse connection string for pool
         connection_params = database_url
         
-        # Ensure SSL mode is set - use 'prefer' instead of 'require'
-        # 'prefer' tries SSL but falls back to non-SSL if SSL connection fails
-        # This prevents "SSL connection has been closed unexpectedly" timeouts
+        # DISABLE SSL completely to debug connection timeouts
+        # Supabase connection pooler (port 6543) may have SSL issues
+        # Try disabling SSL entirely to see if queries work
         if '?' not in connection_params:
-            connection_params += '?sslmode=prefer&connect_timeout=10'
+            connection_params += '?sslmode=disable&connect_timeout=10'
         else:
             if 'sslmode=' not in connection_params:
-                connection_params += '&sslmode=prefer'
+                connection_params += '&sslmode=disable'
             if 'connect_timeout=' not in connection_params:
                 connection_params += '&connect_timeout=10'
         


### PR DESCRIPTION
PROBLEM:
========
Even with sslmode=prefer, database queries still timeout: 🔍 [CALLBACK] Looking up user by supabase_uid: c1946e8f... (hangs - no response, worker timeout)

Previous attempts:
- sslmode=require → SSL connection errors, timeouts
- sslmode=prefer → Still timeouts (no improvement)

HYPOTHESIS:
===========
Supabase connection pooler (port 6543/PgBouncer) may not handle SSL connections properly, causing mid-query failures.

FIX:
====
Completely disable SSL with sslmode=disable to test if non-SSL connections work. This is a DEBUGGING step.

If this works, we'll know it's an SSL configuration issue and can configure proper SSL settings for Supabase.

If this still fails, the issue is elsewhere (not SSL).