### PR TITLE
Fix DSN parsing error - URL-encode options parameter

### DIFF
--- a/src/database/db.py
+++ b/src/database/db.py
@@ -34,15 +34,21 @@ def _get_connection_pool():
         
         # Supabase pooler REQUIRES SSL - cannot use sslmode=disable
         # Add aggressive timeouts to prevent hanging queries
+        # URL-encode the options parameter since it contains = signs
+        from urllib.parse import quote
+
         if '?' not in connection_params:
-            connection_params += '?sslmode=require&connect_timeout=5&options=-c statement_timeout=10000'
+            # URL-encode: -c statement_timeout=10000
+            options_encoded = quote('-c statement_timeout=10000')
+            connection_params += f'?sslmode=require&connect_timeout=5&options={options_encoded}'
         else:
             if 'sslmode=' not in connection_params:
                 connection_params += '&sslmode=require'
             if 'connect_timeout=' not in connection_params:
                 connection_params += '&connect_timeout=5'
             if 'statement_timeout' not in connection_params:
-                connection_params += '&options=-c statement_timeout=10000'
+                options_encoded = quote('-c statement_timeout=10000')
+                connection_params += f'&options={options_encoded}'
         
         # Create connection pool with conservative settings
         # Small pool size to avoid overwhelming Supabase pooler


### PR DESCRIPTION
PROBLEM:
========
Deployment failed with:
'invalid dsn: extra key/value separator "=" in URI query parameter: "options"'

The options parameter:
  options=-c statement_timeout=10000

Contains = signs that confuse the psycopg2 URI parser.

FIX:
====
URL-encode the options value:
  -c statement_timeout=10000 → -c%20statement_timeout%3D10000

This makes the connection string valid.

Now the query timeout will work without breaking the DSN.