### PR TITLE
Fix bad_oauth_state by migrating from filesystem to Redis sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ OPENAI_API_KEY=your_openai_key_here (optional)
 # Flask Configuration
 FLASK_SECRET_KEY=your-secret-key-here
 
+# Redis Configuration (for production session storage on Render)
+# Get this from Render Dashboard → New → Redis → Copy connection URL
+# Format: rediss://redis:password@redis-service:6379/0
+REDIS_URL=
+
 # Supabase Configuration (for Google OAuth)
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your-anon-key-here

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ flask-login>=0.6.3
 flask-session>=0.6.0  # Server-side session storage for multi-worker support
 flask-mail>=0.10.0  # Email sending for account verification
 cachelib>=0.10.0  # Required by flask-session
+redis>=5.0.0  # Redis for production session storage (ephemeral filesystem fix)
 werkzeug>=3.0.0
 gunicorn>=21.2.0  # Production WSGI server for Render deployment
 gevent>=23.9.1  # Async worker for better upload handling

--- a/web_app.py
+++ b/web_app.py
@@ -71,27 +71,48 @@ print(f"   - Cookie HTTPOnly: {app.config['SESSION_COOKIE_HTTPONLY']}", flush=Tr
 # ============================================================================
 # FLASK-SESSION CONFIGURATION (Server-side session storage)
 # ============================================================================
-# CRITICAL: Use filesystem-based sessions to persist across workers/restarts
-# This fixes the "flow_state_not_found" error from Supabase OAuth
+# CRITICAL: Use Redis for production to persist sessions across workers/restarts
+# This fixes the "bad_oauth_state" error on Render's ephemeral filesystem
 
-# Create session directory in data folder (survives restarts if on persistent disk)
-session_dir = Path('./data/flask_session')
-session_dir.mkdir(parents=True, exist_ok=True)
+redis_url = os.getenv('REDIS_URL')
 
-app.config['SESSION_TYPE'] = 'filesystem'  # Store sessions on disk
-app.config['SESSION_FILE_DIR'] = str(session_dir)
-app.config['SESSION_PERMANENT'] = False  # Session expires when browser closes
-app.config['SESSION_USE_SIGNER'] = True  # Sign session cookies for security
-app.config['SESSION_FILE_THRESHOLD'] = 500  # Max number of session files
+if redis_url:
+    # Production: Use Redis for session storage (works with ephemeral filesystems)
+    from redis import Redis
 
-# Initialize Flask-Session
-Session(app)
+    print(f"🔧 Configuring Redis session storage...", flush=True)
+    app.config['SESSION_TYPE'] = 'redis'
+    app.config['SESSION_REDIS'] = Redis.from_url(redis_url)
+    app.config['SESSION_PERMANENT'] = False  # Session expires when browser closes
+    app.config['SESSION_USE_SIGNER'] = True  # Sign session cookies for security
 
-print(f"✅ Flask-Session initialized:", flush=True)
-print(f"   - Type: filesystem", flush=True)
-print(f"   - Directory: {session_dir.absolute()}", flush=True)
-print(f"   - Permanent: False", flush=True)
-print(f"   - Use Signer: True", flush=True)
+    # Initialize Flask-Session
+    Session(app)
+
+    print(f"✅ Flask-Session initialized with Redis:", flush=True)
+    print(f"   - Type: redis", flush=True)
+    print(f"   - URL: {redis_url[:20]}...", flush=True)
+    print(f"   - Permanent: False", flush=True)
+    print(f"   - Use Signer: True", flush=True)
+else:
+    # Development: Fall back to filesystem for local development
+    print(f"⚠️  REDIS_URL not set - using filesystem sessions (NOT for production!)", flush=True)
+
+    session_dir = Path('./data/flask_session')
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    app.config['SESSION_TYPE'] = 'filesystem'  # Store sessions on disk
+    app.config['SESSION_FILE_DIR'] = str(session_dir)
+    app.config['SESSION_PERMANENT'] = False  # Session expires when browser closes
+    app.config['SESSION_USE_SIGNER'] = True  # Sign session cookies for security
+    app.config['SESSION_FILE_THRESHOLD'] = 500  # Max number of session files
+
+    # Initialize Flask-Session
+    Session(app)
+
+    print(f"✅ Flask-Session initialized with filesystem:", flush=True)
+    print(f"   - Type: filesystem", flush=True)
+    print(f"   - Directory: {session_dir.absolute()}", flush=True)
 
 # Ensure upload folder exists
 Path(app.config['UPLOAD_FOLDER']).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This fixes the OAuth session persistence issue on Render's ephemeral filesystem.

Changes:
- Add redis>=5.0.0 dependency to requirements.txt
- Update web_app.py and web_app_minimal.py to use Redis sessions when REDIS_URL is set
- Fall back to filesystem sessions for local development when REDIS_URL is not set
- Update .env.example with REDIS_URL configuration instructions

Root cause: Render's ephemeral filesystem + Gunicorn worker restarts were destroying filesystem-based sessions during OAuth flow, causing bad_oauth_state errors.

Solution: Redis provides persistent session storage that survives worker restarts and works across multiple workers on ephemeral filesystems.

After deploy:
1. Create Redis instance on Render (Dashboard → New → Redis)
2. Add REDIS_URL environment variable to Render web service
3. Redeploy the application