### PR TITLE
Use PostgreSQL for session storage instead of Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,6 @@ OPENAI_API_KEY=your_openai_key_here (optional)
 # Flask Configuration
 FLASK_SECRET_KEY=your-secret-key-here
 
-# Redis Configuration (for production session storage on Render)
-# Get this from Render Dashboard → New → Redis → Copy connection URL
-# Format: rediss://redis:password@redis-service:6379/0
-REDIS_URL=
-
 # Supabase Configuration (for Google OAuth)
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your-anon-key-here

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,13 +25,14 @@ flask-login>=0.6.3
 flask-session>=0.6.0  # Server-side session storage for multi-worker support
 flask-mail>=0.10.0  # Email sending for account verification
 cachelib>=0.10.0  # Required by flask-session
-redis>=5.0.0  # Redis for production session storage (ephemeral filesystem fix)
+flask-sqlalchemy>=3.0.0  # SQLAlchemy integration for database sessions
 werkzeug>=3.0.0
 gunicorn>=21.2.0  # Production WSGI server for Render deployment
 gevent>=23.9.1  # Async worker for better upload handling
 
 # Database
 psycopg2-binary>=2.9.9  # PostgreSQL adapter
+sqlalchemy>=2.0.0  # ORM for database session storage
 
 # Authentication (Supabase OAuth)
 supabase>=2.3.0  # Supabase Python client

--- a/web_app.py
+++ b/web_app.py
@@ -71,32 +71,52 @@ print(f"   - Cookie HTTPOnly: {app.config['SESSION_COOKIE_HTTPONLY']}", flush=Tr
 # ============================================================================
 # FLASK-SESSION CONFIGURATION (Server-side session storage)
 # ============================================================================
-# CRITICAL: Use Redis for production to persist sessions across workers/restarts
+# CRITICAL: Use PostgreSQL database for session storage to persist across workers/restarts
 # This fixes the "bad_oauth_state" error on Render's ephemeral filesystem
 
-redis_url = os.getenv('REDIS_URL')
+database_url = os.getenv('DATABASE_URL')
 
-if redis_url:
-    # Production: Use Redis for session storage (works with ephemeral filesystems)
-    from redis import Redis
+if database_url:
+    # Production: Use PostgreSQL database for session storage
+    from flask_sqlalchemy import SQLAlchemy
 
-    print(f"🔧 Configuring Redis session storage...", flush=True)
-    app.config['SESSION_TYPE'] = 'redis'
-    app.config['SESSION_REDIS'] = Redis.from_url(redis_url)
+    print(f"🔧 Configuring database session storage...", flush=True)
+
+    # Configure SQLAlchemy
+    app.config['SQLALCHEMY_DATABASE_URI'] = database_url
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
+        'pool_pre_ping': True,
+        'pool_recycle': 300,
+    }
+
+    # Configure Flask-Session to use SQLAlchemy
+    app.config['SESSION_TYPE'] = 'sqlalchemy'
     app.config['SESSION_PERMANENT'] = False  # Session expires when browser closes
     app.config['SESSION_USE_SIGNER'] = True  # Sign session cookies for security
+    app.config['SESSION_SQLALCHEMY_TABLE'] = 'flask_sessions'
+
+    # Initialize SQLAlchemy
+    db_sessions = SQLAlchemy(app)
+
+    # Set the SQLAlchemy instance for Flask-Session
+    app.config['SESSION_SQLALCHEMY'] = db_sessions
 
     # Initialize Flask-Session
     Session(app)
 
-    print(f"✅ Flask-Session initialized with Redis:", flush=True)
-    print(f"   - Type: redis", flush=True)
-    print(f"   - URL: {redis_url[:20]}...", flush=True)
+    # Create sessions table if it doesn't exist
+    with app.app_context():
+        db_sessions.create_all()
+
+    print(f"✅ Flask-Session initialized with PostgreSQL:", flush=True)
+    print(f"   - Type: sqlalchemy (PostgreSQL)", flush=True)
+    print(f"   - Table: flask_sessions", flush=True)
     print(f"   - Permanent: False", flush=True)
     print(f"   - Use Signer: True", flush=True)
 else:
     # Development: Fall back to filesystem for local development
-    print(f"⚠️  REDIS_URL not set - using filesystem sessions (NOT for production!)", flush=True)
+    print(f"⚠️  DATABASE_URL not set - using filesystem sessions (local dev only!)", flush=True)
 
     session_dir = Path('./data/flask_session')
     session_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Switched from Redis to PostgreSQL (SQLAlchemy) for session storage since Redis is not available on Render without additional setup.

Changes:
- Replace redis dependency with flask-sqlalchemy and sqlalchemy
- Update web_app.py to use SQLAlchemy session backend
- Update web_app_minimal.py to use SQLAlchemy session backend
- Remove REDIS_URL from .env.example
- Automatically create flask_sessions table in PostgreSQL

Benefits:
- Uses existing PostgreSQL database (no additional services needed)
- Sessions persist across worker restarts
- Works on Render's ephemeral filesystem
- Solves bad_oauth_state error

The app will automatically create a flask_sessions table in your existing PostgreSQL database to store session data.