### PR TITLE
Fix index route not passing is_guest variable to template

### DIFF
--- a/web_app.py
+++ b/web_app.py
@@ -284,10 +284,8 @@ def debug_config():
 @app.route('/')
 def index():
     """Landing page / dashboard"""
-    if current_user.is_authenticated:
-        return render_template('index.html')
-    else:
-        return render_template('index.html')
+    is_guest = not current_user.is_authenticated
+    return render_template('index.html', is_guest=is_guest)
 
 @app.route('/data/<path:filename>')
 def serve_data_files(filename):


### PR DESCRIPTION
The index route was rendering index.html without passing the is_guest variable, causing logged-in users to see the marketing page instead of the dashboard.

Now properly sets is_guest = not current_user.is_authenticated and passes it to the template, so authenticated users see their dashboard.