### PR TITLE
Fix navigation links for inventory and invoicing routes

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1224,14 +1224,14 @@
         </div>
 
         <div class="nav-item">
-            <a href="{{ url_for('inventory') }}" class="nav-link {% if request.endpoint == 'inventory' %}active{% endif %}">
+            <a href="{{ url_for('main.inventory') }}" class="nav-link {% if request.endpoint == 'main.inventory' %}active{% endif %}">
                 <i class="fas fa-boxes"></i>
                 <span>Inventory</span>
             </a>
         </div>
 
         <div class="nav-item">
-            <a href="{{ url_for('invoicing') }}" class="nav-link {% if request.endpoint == 'invoicing' %}active{% endif %}">
+            <a href="{{ url_for('main.invoicing') }}" class="nav-link {% if request.endpoint == 'main.invoicing' %}active{% endif %}">
                 <i class="fas fa-file-invoice-dollar"></i>
                 <span>Invoicing</span>
             </a>


### PR DESCRIPTION
The inventory and invoicing routes are defined in the main_bp blueprint, so url_for() calls need to use 'main.inventory' and 'main.invoicing' instead of just 'inventory' and 'invoicing'.

This was causing navigation to fail because Flask couldn't resolve the route names without the blueprint prefix.