### PR TITLE
Migrate to Redis-based sessions using Upstash Redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,13 @@ customtkinter>=5.2.0
 flask>=3.0.0
 flask-login>=0.6.3
 flask-mail>=0.10.0  # Email sending for account verification
+flask-session>=0.8.0  # Redis-backed server-side sessions
 werkzeug>=3.0.0
 gunicorn>=21.2.0  # Production WSGI server for Render deployment
 gevent>=23.9.1  # Async worker for better upload handling
+
+# Session storage (Upstash Redis)
+redis>=5.0.0  # Redis client for session storage and OAuth state
 
 # Database
 psycopg2-binary>=2.9.9  # PostgreSQL adapter

--- a/src/auth_utils.py
+++ b/src/auth_utils.py
@@ -3,6 +3,10 @@ Supabase Authentication Utilities
 ===================================
 Google OAuth integration with Supabase
 Based on: https://supabase.com/blog/oauth2-login-python-flask-apps
+
+Uses Redis (Upstash) for:
+- Flask session storage (via Flask-Session)
+- OAuth state/PKCE verifier storage (via direct Redis operations with TTL)
 """
 
 import os
@@ -13,6 +17,149 @@ from flask import g
 from werkzeug.local import LocalProxy
 from supabase.client import Client, ClientOptions
 from src.flask_storage import FlaskSessionStorage
+import redis
+
+
+# ============================================================================
+# REDIS CLIENT FOR OAUTH STATE STORAGE
+# ============================================================================
+
+def get_redis_client() -> Optional[redis.Redis]:
+    """
+    Get Redis client for OAuth state/PKCE storage.
+
+    Uses REDIS_URL from environment variables.
+    Stores client in Flask's g object for request-scoped access.
+
+    Returns:
+        Redis client instance or None if not configured
+    """
+    if "redis_client" not in g:
+        redis_url = os.getenv("REDIS_URL")
+        if not redis_url:
+            print("[REDIS] REDIS_URL not configured")
+            return None
+
+        try:
+            g.redis_client = redis.from_url(
+                redis_url,
+                decode_responses=True,  # Decode responses to strings
+                socket_connect_timeout=5,
+                socket_timeout=5
+            )
+            # Test connection
+            g.redis_client.ping()
+        except Exception as e:
+            print(f"[REDIS] Failed to connect: {e}")
+            return None
+
+    return g.redis_client
+
+
+def store_oauth_state(state: str, flow_id: str, ttl: int = 600) -> bool:
+    """
+    Store OAuth state in Redis with TTL.
+
+    Args:
+        state: OAuth state parameter (for CSRF protection)
+        flow_id: Unique flow identifier
+        ttl: Time to live in seconds (default: 10 minutes)
+
+    Returns:
+        True if stored successfully, False otherwise
+    """
+    client = get_redis_client()
+    if not client:
+        return False
+
+    try:
+        key = f"resell_rebel:oauth:state:{state}"
+        client.setex(key, ttl, flow_id)
+        print(f"[REDIS] Stored OAuth state with TTL {ttl}s")
+        return True
+    except Exception as e:
+        print(f"[REDIS] Failed to store OAuth state: {e}")
+        return False
+
+
+def verify_oauth_state(state: str) -> Optional[str]:
+    """
+    Verify and retrieve OAuth state from Redis.
+
+    Args:
+        state: OAuth state parameter to verify
+
+    Returns:
+        flow_id if state is valid, None otherwise
+    """
+    client = get_redis_client()
+    if not client:
+        return None
+
+    try:
+        key = f"resell_rebel:oauth:state:{state}"
+        flow_id = client.get(key)
+        if flow_id:
+            # Delete after retrieval (one-time use)
+            client.delete(key)
+            print(f"[REDIS] OAuth state verified and consumed")
+        return flow_id
+    except Exception as e:
+        print(f"[REDIS] Failed to verify OAuth state: {e}")
+        return None
+
+
+def store_pkce_verifier(flow_id: str, code_verifier: str, ttl: int = 600) -> bool:
+    """
+    Store PKCE code verifier in Redis with TTL.
+
+    Args:
+        flow_id: Unique flow identifier
+        code_verifier: PKCE code verifier
+        ttl: Time to live in seconds (default: 10 minutes)
+
+    Returns:
+        True if stored successfully, False otherwise
+    """
+    client = get_redis_client()
+    if not client:
+        return False
+
+    try:
+        key = f"resell_rebel:oauth:pkce:{flow_id}"
+        client.setex(key, ttl, code_verifier)
+        print(f"[REDIS] Stored PKCE verifier with TTL {ttl}s")
+        return True
+    except Exception as e:
+        print(f"[REDIS] Failed to store PKCE verifier: {e}")
+        return False
+
+
+def get_pkce_verifier(flow_id: str) -> Optional[str]:
+    """
+    Retrieve PKCE code verifier from Redis.
+
+    Args:
+        flow_id: Unique flow identifier
+
+    Returns:
+        code_verifier if found, None otherwise
+    """
+    client = get_redis_client()
+    if not client:
+        return None
+
+    try:
+        key = f"resell_rebel:oauth:pkce:{flow_id}"
+        code_verifier = client.get(key)
+        if code_verifier:
+            # Delete after retrieval (one-time use)
+            client.delete(key)
+            print(f"[REDIS] PKCE verifier retrieved and consumed")
+        return code_verifier
+    except Exception as e:
+        print(f"[REDIS] Failed to get PKCE verifier: {e}")
+        return None
 
 
 def get_supabase_client() -> Client:
@@ -60,11 +207,13 @@ def get_google_oauth_url(session_storage: dict = None, redirect_override: Option
 
     The Supabase client with flow_type="pkce" automatically handles:
     - Generating code_verifier
-    - Storing it in Flask session via FlaskSessionStorage
+    - Storing it in Flask session (Redis-backed) via FlaskSessionStorage
     - Creating the OAuth URL with proper parameters
 
+    Additionally stores OAuth state in Redis for extra CSRF protection.
+
     Returns:
-        Tuple (oauth_url, flow_id) or None if Supabase is not configured
+        Tuple (oauth_url, flow_id, state) or None if Supabase is not configured
     """
     # Get redirect URL from environment, or try to construct from request
     redirect_url = redirect_override or os.getenv("SUPABASE_REDIRECT_URL", "").strip()
@@ -87,23 +236,31 @@ def get_google_oauth_url(session_storage: dict = None, redirect_override: Option
     try:
         print(f"[OAUTH] Generating OAuth URL for redirect: {redirect_url}")
 
-        # Generate random flow_id for tracking (optional, not required by Supabase)
+        # Generate random flow_id and state for CSRF protection
         flow_id = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode().rstrip('=')
+        state = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode().rstrip('=')
 
-        # Store flow_id in session for tracking
+        # Store flow_id in Flask session (Redis-backed) for tracking
         if session_storage is not None:
             session_storage['oauth_flow_id'] = flow_id
-            print(f"[OAUTH] Stored flow_id in session")
+            session_storage['oauth_state'] = state
+            print(f"[OAUTH] Stored flow_id and state in Redis session")
+
+        # Also store state in Redis with TTL for extra security
+        store_oauth_state(state, flow_id, ttl=600)  # 10 minutes
 
         # Use Supabase client to generate OAuth URL
         # The client with flow_type="pkce" automatically:
         # - Generates code_verifier
-        # - Stores it in FlaskSessionStorage
-        # - Returns the OAuth URL
+        # - Stores it in FlaskSessionStorage (which uses Redis via Flask-Session)
+        # - Returns the OAuth URL with state parameter
         response = client.auth.sign_in_with_oauth({
             "provider": "google",
             "options": {
-                "redirect_to": redirect_url
+                "redirect_to": redirect_url,
+                "query_params": {
+                    "state": state  # Add state for CSRF protection
+                }
             }
         })
 
@@ -111,8 +268,9 @@ def get_google_oauth_url(session_storage: dict = None, redirect_override: Option
         print(f"[OAUTH] Generated OAuth URL using Supabase client with PKCE")
         print(f"[OAUTH] Redirect URL: {redirect_url}")
         print(f"[OAUTH] OAuth URL: {oauth_url[:150]}...")
+        print(f"[OAUTH] State parameter: {state[:20]}...")
 
-        return oauth_url, flow_id
+        return oauth_url, flow_id, state
 
     except Exception as e:
         print(f"[OAUTH] Error generating OAuth URL: {e}")


### PR DESCRIPTION
BREAKING CHANGE: Sessions now require REDIS_URL environment variable

Changes:
- web_app.py: Configure Flask-Session with Redis backend
  * Replace cookie-based sessions with server-side Redis storage
  * Add Redis connection validation at startup
  * Configure session settings for OAuth compatibility

- src/auth_utils.py: Add Redis helpers for OAuth state/PKCE
  * Add get_redis_client() for direct Redis access
  * Add store_oauth_state() for CSRF protection
  * Add verify_oauth_state() for callback validation
  * Add store_pkce_verifier() and get_pkce_verifier()
  * Update get_google_oauth_url() to store state in Redis with TTL

- routes_auth.py: Update OAuth flow to use Redis
  * Update login_google() to handle new return values
  * Update auth_callback() to verify state using Redis
  * Add fallback to Flask session for state validation
  * Improve logging for Redis session operations

- requirements.txt: Add Redis dependencies
  * Add flask-session>=0.8.0 for Redis-backed sessions
  * Add redis>=5.0.0 for Upstash Redis client

Benefits:
- Server-side session storage (more secure)
- Supports multi-worker deployments
- Works with ephemeral filesystems (Render, Heroku)
- TTL-based expiration for OAuth state/PKCE
- Better CSRF protection with Redis-backed state