### PR TITLE
Fix OAuth newline header error preventing Google login

### DIFF
--- a/routes_auth.py
+++ b/routes_auth.py
@@ -582,6 +582,10 @@ def login_google():
 
         oauth_url, flow_id, state = oauth_result
 
+        # CRITICAL: Strip newlines from OAuth URL to prevent header errors
+        # Environment variables or Supabase response may contain newlines
+        oauth_url = oauth_url.strip() if oauth_url else ""
+
         # CRITICAL: Mark session as modified to ensure it's saved to Redis
         # This is important for Redis-backed sessions
         session.modified = True

--- a/src/auth_utils.py
+++ b/src/auth_utils.py
@@ -278,6 +278,10 @@ def get_google_oauth_url(session_storage: dict = None, redirect_override: Option
         })
 
         oauth_url = response.url
+
+        # CRITICAL: Strip any whitespace/newlines to prevent HTTP header errors
+        oauth_url = oauth_url.strip() if oauth_url else ""
+
         print(f"[OAUTH] Generated OAuth URL using Supabase client with PKCE")
         print(f"[OAUTH] Redirect URL: {redirect_url}")
         print(f"[OAUTH] OAuth URL: {oauth_url[:150]}...")


### PR DESCRIPTION
Root cause: OAuth URL from Supabase contains newline characters

Error:
  ValueError: Header values must not contain newline characters.
  Location: /login/google route when redirecting to oauth_url

Fix:
- Strip oauth_url in routes_auth.py before redirect (line 587)
- Strip oauth_url in auth_utils.py after Supabase response (line 283)

This prevents HTTP header errors when environment variables or Supabase responses contain trailing whitespace/newlines.

Fixes the "OAuth authentication failed" error on Render deployments.